### PR TITLE
exports "normalizeKeyDescriptorString(origDescriptor)"

### DIFF
--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -1455,7 +1455,8 @@ define(function (require, exports, module) {
     exports.getKeyBindings = getKeyBindings;
     exports.addGlobalKeydownHook = addGlobalKeydownHook;
     exports.removeGlobalKeydownHook = removeGlobalKeydownHook;
-
+    exports.normalizeKeyDescriptorString = normalizeKeyDescriptorString;
+    
     /**
      * Use windows-specific bindings if no other are found (e.g. Linux).
      * Core Brackets modules that use key bindings should always define at


### PR DESCRIPTION
The function "**normalizeKeyDescriptorString(origDescriptor)**" is **not** declared as **private** (also apply to the API documentation), though it wasn't exported.
The function should be made available, since it may be useful to develop extensions e.g. to check if a key is already bound by looking up in the key map for the corresponding (normalized) descriptor.
See: http://brackets.io/docs/current/modules/command/KeyBindingManager.html